### PR TITLE
Fix #32: Add own devices as possible OMEMO partners.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -190,7 +190,7 @@ class OmemoPlugin(GajimPlugin):
         if contact_jid == my_jid:
             log.info(account_name + ' ⇒ Received own device_list:' + str(
                 devices_list))
-            state.add_own_devices(devices_list)
+            state.add_own_devices(my_jid, devices_list)
 
             if not state.own_device_id_published() or anydup(
                     state.own_devices):
@@ -236,7 +236,8 @@ class OmemoPlugin(GajimPlugin):
         if account_name not in self.ui_list:
             self.ui_list[account_name] = {}
         state = self.get_omemo_state(account_name)
-        if contact_jid in state.device_ids:
+        my_jid = gajim.get_jid_from_account(account_name)
+        if contact_jid in state.device_ids or contact_jid == my_jid:
             log.debug(account_name + " ⇒ Adding OMEMO ui for " + contact_jid)
             omemo_enabled = state.encryption.is_active(contact_jid)
             self.ui_list[account_name][contact_jid] = Ui(self, chat_control,

--- a/lib/python-omemo/src/omemo/state.py
+++ b/lib/python-omemo/src/omemo/state.py
@@ -22,6 +22,7 @@ from base64 import b64encode
 
 from axolotl.ecc.djbec import DjbECPublicKey
 from axolotl.identitykey import IdentityKey
+from axolotl.duplicatemessagexception import DuplicateMessageException
 from axolotl.invalidmessageexception import InvalidMessageException
 from axolotl.invalidversionexception import InvalidVersionException
 from axolotl.nosessionexception import NoSessionException
@@ -36,14 +37,15 @@ from Crypto.Random import get_random_bytes
 from .aes_gcm import NoValidSessions, aes_decrypt, aes_encrypt
 from .liteaxolotlstore import LiteAxolotlStore
 
-log = logging.getLogger('omemo')
-
+#log = logging.getLogger('omemo')
+log = logging.getLogger('gajim.plugin_system.omemo')
 
 class OmemoState:
     session_ciphers = {}
     encryption = None
 
     device_ids = {}
+    own_name = ''
     own_devices = []
 
     def __init__(self, connection):
@@ -89,7 +91,7 @@ class OmemoState:
         log.debug('Saving devices for ' + name + ' → ' + str(devices))
         self.device_ids[name] = devices
 
-    def add_own_devices(self, devices):
+    def add_own_devices(self, name, devices):
         """ Overwrite the current :py:attribute:`OmemoState.own_devices` with
             the given devices.
 
@@ -98,6 +100,7 @@ class OmemoState:
             devices : [int]
                 A list of device_ids
         """
+        self.own_name = name
         self.own_devices = devices
 
     @property
@@ -163,6 +166,19 @@ class OmemoState:
                 log.error('sender_jid →  ' + str(sender_jid) + ' sid =>' + str(
                     sid))
                 return
+            except (DuplicateMessageException) as e:
+                log.error('Duplicate message found ' + str(e.args))
+                log.error('sender_jid → ' + str(sender_jid) + ' sid => ' +str(sid))
+                return
+            except (Exception) as e:
+                log.error('Duplicate message found ' + str(e.args))
+                log.error('sender_jid → ' + str(sender_jid) + ' sid => ' +str(sid))
+                return
+
+        except (DuplicateMessageException):
+            log.error('Duplicate message found ' + e.message)
+            log.error('sender_jid → ' + str(sender_jid) + ' sid => ' +str(sid))
+            return
 
         result = unicode(aes_decrypt(key, iv, payload))
         log.debug("Decrypted msg ⇒ " + result)
@@ -224,6 +240,8 @@ class OmemoState:
             jid : string
                 The contacts jid
         """
+        if jid == self.own_name:
+            return set(self.own_devices) - set({self.own_device_id})
         if jid not in self.device_ids:
             return set()
         return set(self.device_ids[jid])


### PR DESCRIPTION
- Adds handling of duplicate messages for `decrypt_msg`
- Adds support for sending OMEMO encrypted messages to own devices
