### PR TITLE
Check for new fingerprints on send button pressed

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -145,7 +145,7 @@ class Ui(object):
 
         def omemo_send_message(message, keyID='', chatstate=None, xhtml=None,
                                process_commands=True, attention=False):
-
+            self.new_fingerprints_available()
             if self.encryption_active() and \
                     self.plugin.are_keys_missing(self.account,
                                                  self.contact.jid):


### PR DESCRIPTION
Check if there are new fingerprints in the DB on send button pressed.

In the latest commits new fingerprints are only checked if there was no session before and we query for the bundle.

But a PreKeyWhisperMessage from a contact adds also the Fingerprint to our DB and creates a session without ever query the bundle of the contact. So we check now on every send button pressed event if there are new keys added to out DB.
