### PR TITLE
Fix manifest syntax

### DIFF
--- a/manifest.ini
+++ b/manifest.ini
@@ -2,8 +2,7 @@
 name: OMEMO
 short_name: omemo
 version: 0.8.1
-description: OMEMO is an XMPP Extension Protocol (XEP) for secure multi-client end-to-end encryption based on Axolotl and PEP. 
-You need to install some dependencys, you can find install instructions for your system in the Github Wiki.
+description: OMEMO is an XMPP Extension Protocol (XEP) for secure multi-client end-to-end encryption based on Axolotl and PEP. You need to install some dependencys, you can find install instructions for your system in the Github Wiki.
 authors: Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
  Daniel Gultsch <daniel@gultsch.de>
  Philipp Hörist <philipp@hoerist.com>


### PR DESCRIPTION
Commit 9d7306001 introduced a syntax error by including a line break in the description. This results in a parsing error when starting gajim:

```
ConfigParser.ParsingError: File contains parsing errors: /home/klemens/.local/share/gajim/plugins/gajim-omemo/manifest.ini
    [line  6]: 'You need to install some dependencys, you can find install instructions for your system in the Github Wiki.\n'
```
